### PR TITLE
Enhance iptables-detect.sh to support RHEL-like OS versions 

### DIFF
--- a/iptables-detect/iptables-detect.sh
+++ b/iptables-detect/iptables-detect.sh
@@ -171,7 +171,8 @@ os_detect() {
 
     oracleserver)
         dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
-        if [ "$dist_version" -ge 8 ]; then
+        maj_ver=$(sed -E -e "s/^([0-9]+)\.?[0-9]*$/\1/" <<<$dist_version)
+        if [ "$maj_ver" -ge 8 ]; then
             detected_via=os
             mode=nft
         else
@@ -194,7 +195,8 @@ os_detect() {
 
     centos | redhat)
         dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
-        if [ "$dist_version" -ge 8 ]; then
+        maj_ver=$(sed -E -e "s/^([0-9]+)\.?[0-9]*$/\1/" <<<$dist_version)
+        if [ "$maj_ver" -ge 8 ]; then    
             detected_via=os
             mode=nft
         else


### PR DESCRIPTION
Enhance iptables-detect.sh to support RHEL-like OS versions where there is a decimal in the version ID.

This is specifically for RHEL versions like `7.8` or `8.0`, which originally threw the script off. This still works with CentOS versions where `VERSION_ID` in `/etc/os-release` is `7` or `8` etc., as it is lazy in attempting to match. 

https://github.com/rancher/k3s/issues/1812

Signed-off-by: Chris Kim <oats87g@gmail.com>