### PR TITLE
Correct redirection error

### DIFF
--- a/iptables-detect/iptables-detect.sh
+++ b/iptables-detect/iptables-detect.sh
@@ -171,7 +171,7 @@ os_detect() {
 
     oracleserver)
         dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
-        maj_ver=$(sed -E -e "s/^([0-9]+)\.?[0-9]*$/\1/" <<<$dist_version)
+        maj_ver=$(echo $dist_version | sed -E -e "s/^([0-9]+)\.?[0-9]*$/\1/")
         if [ "$maj_ver" -ge 8 ]; then
             detected_via=os
             mode=nft
@@ -195,7 +195,7 @@ os_detect() {
 
     centos | redhat)
         dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
-        maj_ver=$(sed -E -e "s/^([0-9]+)\.?[0-9]*$/\1/" <<<$dist_version)
+        maj_ver=$(echo $dist_version | sed -E -e "s/^([0-9]+)\.?[0-9]*$/\1/")
         if [ "$maj_ver" -ge 8 ]; then    
             detected_via=os
             mode=nft


### PR DESCRIPTION
CI is failing attempting to integrate the latest RHEL changes due to an incompatibility with redirection. This simply eliminates the redirection and replaces it with an `echo` and `|`.

Part of: https://github.com/rancher/k3s/issues/1812

Signed-off-by: Chris Kim <oats87g@gmail.com>